### PR TITLE
Article updates

### DIFF
--- a/articles/20250325T1830-npr-days-after-the-signal-leak-the-pentagon-warned-the-app-was-the-target-of-hackers.md
+++ b/articles/20250325T1830-npr-days-after-the-signal-leak-the-pentagon-warned-the-app-was-the-target-of-hackers.md
@@ -1,0 +1,13 @@
+---
+url: https://www.npr.org/2025/03/25/nx-s1-5339801/pentagon-email-signal-vulnerability
+title: Days after the Signal leak, the Pentagon warned the app was the target of hackers
+publisher: npr
+usage: candidate
+initial_rank: 3
+---
+## Article summary
+Following a recent incident where a reporter was inadvertently included in a sensitive Signal chat regarding military operations, the Pentagon issued a warning about the messaging app being targeted by hackers. The advisory, dated March 18, cautioned against using Signal for any unclassified information due to identified vulnerabilities exploited by Russian hacking groups. It emphasized that while Signal can be used for unclassified exercises, it is not approved for processing or storing sensitive information. 
+
+The memo highlighted concerns over phishing attacks aimed at Signal users, prompting the app to implement additional safeguards. A previous Pentagon memo from 2023 also restricted the use of mobile applications for controlled unclassified information. The incident raised alarms about the sharing of sensitive military intelligence in unsecured forums, with experts criticizing the lack of caution among high-level officials. 
+
+The situation underscores the risks associated with using third-party messaging applications in national security contexts. The Pentagon's warning serves as a reminder of the importance of secure communication channels in safeguarding sensitive information.

--- a/articles/20250325T1830-npr-heads-are-exploding.md
+++ b/articles/20250325T1830-npr-heads-are-exploding.md
@@ -1,0 +1,11 @@
+---
+url: https://www.npr.org/2025/03/25/nx-s1-5339753/signal-war-plan-breach-security-experts
+title: '''Heads are exploding'': How security experts see the Signal war-plan breach'
+publisher: npr
+usage: top
+initial_rank: 1
+---
+## Article summary
+The Signal war-plan breach has shocked security experts and military officials after a journalist was inadvertently added to a group chat where top U.S. officials discussed sensitive military operations against Houthi rebels in Yemen. The incident raised serious concerns about the decision to use a free messaging app for classified discussions, prompting questions about security protocols. Former military personnel expressed disbelief, noting that such actions would lead to severe consequences for regular service members. The breach highlighted the contrast between typical secure communication methods, such as utilizing the White House Situation Room or secure video teleconferencing, and the casual use of an open-source app like Signal.
+
+Despite the encryption that Signal provides, experts emphasized that sensitive government communications should occur through official channels with robust security measures. Following the breach, the Pentagon issued a warning about potential vulnerabilities in the app, particularly concerning phishing attacks from foreign hackers. The incident has led to scrutiny of the national security officials involved, as they typically prioritize secure communications. Overall, the breach has left many in the intelligence community baffled by the lax approach to handling classified information.

--- a/articles/20250325T1830-npr-intelligence-leaders-testify.md
+++ b/articles/20250325T1830-npr-intelligence-leaders-testify.md
@@ -1,0 +1,10 @@
+---
+url: https://www.npr.org/2025/03/25/nx-s1-5339484/signal-war-plans-congress
+title: 'Intelligence leaders testify: We didn''t share classified information in that
+  Signal chat group '
+publisher: npr
+usage: candidate
+initial_rank: 2
+---
+## Article summary
+In a recent congressional hearing, CIA Director John Ratcliffe and Director of National Intelligence Tulsi Gabbard asserted that they did not share classified information in a Signal chat group discussing a U.S. bombing campaign in Yemen. This testimony came amid scrutiny following an incident where journalist Jeffrey Goldberg was mistakenly added to the group, which included high-ranking officials like Vice President JD Vance and Defense Secretary Pete Hegseth. Democratic senators challenged the intelligence leaders' claims, demanding transparency and evidence regarding the chat's content. Ratcliffe maintained that his messages were lawful and did not contain classified material, while Gabbard refrained from confirming her participation. The National Security Council acknowledged the authenticity of the chat but stated it was reviewing how Goldberg was added. Critics have raised concerns over the use of Signal, a publicly available app, for sensitive discussions, highlighting that such matters should occur in secure facilities. Lawmakers from both parties have expressed alarm over the breach, with calls for further investigation into the incident. The Pentagon had previously warned against using Signal due to vulnerabilities, and lawmakers are now demanding accountability for the security lapse.

--- a/articles/20250325T1830-nytimes-after-signal-leak-jd-vance-focuses-on-proving-his-loyalty-to-trump.md
+++ b/articles/20250325T1830-nytimes-after-signal-leak-jd-vance-focuses-on-proving-his-loyalty-to-trump.md
@@ -1,0 +1,11 @@
+---
+url: https://www.nytimes.com/2025/03/25/us/signal-leak-vance-trump.html
+title: After Signal Leak, JD Vance Focuses on Proving His Loyalty to Trump
+publisher: nytimes
+usage: candidate
+initial_rank: 3
+---
+## Article summary
+The article discusses Vice President JD Vance's response following a signal leak that revealed his participation in a secret chat regarding a military operation in Yemen. Instead of addressing the security breach, Vance's priority was to reaffirm his loyalty to President Trump after expressing dissent about the timing of the strike. In the leaked conversation, he questioned whether Trump understood the implications of the military action and expressed concerns about European nations benefiting from U.S. military efforts. Vance indicated he would support the consensus among his colleagues but was frustrated with the prospect of "bailing Europe out again." 
+
+His team quickly moved to mitigate the fallout, emphasizing that Vance is fully aligned with Trump’s foreign policy. A spokesman stated that Vance's first priority is ensuring that the president is well-informed about internal discussions. The incident underscores the administration's emphasis on loyalty, as policy disagreements are not well-received. Despite his previous public support for Trump, this incident reveals Vance's internal struggles with certain policies. The article highlights the tension between maintaining loyalty and voicing legitimate concerns within the Trump administration.

--- a/articles/20250325T1830-nytimes-now-europe-knows-what-the-trump-team-calls-it-behind-its-back.md
+++ b/articles/20250325T1830-nytimes-now-europe-knows-what-the-trump-team-calls-it-behind-its-back.md
@@ -1,0 +1,13 @@
+---
+url: https://www.nytimes.com/2025/03/25/world/europe/signal-jeffrey-goldberg-message-hegseth.html
+title: "Now Europe Knows What the Trump Team Calls It Behind Its Back: \u2018Pathetic\u2019"
+publisher: nytimes
+usage: candidate
+initial_rank: 2
+---
+## Article summary
+Leaked messages from a Signal group chat among Trump administration officials reveal a disdainful attitude towards Europe, with Vice President JD Vance and Secretary of Defense Pete Hegseth labeling European nations as "pathetic" and accusing them of freeloading on U.S. military efforts. The discussion, which included operational details about a planned strike on Yemen, highlighted a belief that European nations should compensate the U.S. for military actions that benefit them. European officials expressed anger and exasperation at the contempt shown in these messages, which they feel undermines the longstanding transatlantic alliance.
+
+The leaked exchange reflects broader tensions between the U.S. and Europe, particularly regarding military spending and shared values. Vance's recent speech questioning European democracy and values further exacerbated these tensions. While European leaders seek to bolster their defense budgets and maintain the alliance, they are increasingly aware of the U.S.'s shifting stance towards Europe, which includes demands for financial contributions and a more transactional relationship.
+
+The incident raises concerns about security protocols, as discussing sensitive military plans on a messaging app could jeopardize intelligence sharing and trust between allies. Overall, the situation indicates a potential fracture in U.S.-European relations, with European officials contemplating a future where the alliance may not hold the same significance as it once did.

--- a/articles/20250325T1830-nytimes-top-officials-reject-responsibility-for-information-shared-in-signal-chat.md
+++ b/articles/20250325T1830-nytimes-top-officials-reject-responsibility-for-information-shared-in-signal-chat.md
@@ -1,0 +1,9 @@
+---
+url: https://www.nytimes.com/live/2025/03/25/us/trump-hegseth-war-plans-leak-signal
+title: Top Officials Reject Responsibility for Information Shared in Signal Chat
+publisher: nytimes
+usage: top
+initial_rank: 1
+---
+## Article summary
+During a Senate Intelligence Committee hearing, top intelligence officials, including CIA Director John Ratcliffe and Director of National Intelligence Tulsi Gabbard, denied that classified information was shared in a Signal chat that mistakenly included a journalist. The chat discussed U.S. military operations against Houthi rebels in Yemen, sparking outrage among Democratic lawmakers who labeled the incident as careless and a significant security breach. Defense Secretary Pete Hegseth was criticized for sharing sensitive details about the strike timing and targets, with some Democrats calling for his resignation. President Trump downplayed the severity of the leak, defending Hegseth and the national security adviser, Michael Waltz, who inadvertently added the journalist to the chat. Despite assurances from the intelligence officials that no classified information was shared, the Atlantic's editor, Jeffrey Goldberg, contradicted this claim, asserting that the information discussed was sensitive. The incident has led to calls for investigations and highlighted hypocrisy among Republicans who previously criticized similar breaches by Democrats. Lawmakers expressed concern over the implications of discussing military operations on unsecured platforms, emphasizing the need for accountability. The White House has maintained that the information shared did not violate any laws, while Democrats continue to express outrage and demand transparency. The fallout from this incident raises questions about the management of classified information and the responsibilities of those in high-level security positions.


### PR DESCRIPTION
- Created article from npr usage top initial rank 1 with title ''Heads are exploding': How security experts see the Signal war-plan breach
- Created article from npr usage candidate initial rank 2 with title 'Intelligence leaders testify: We didn't share classified information in that Signal chat group 
- Created article from npr usage candidate initial rank 3 with title 'Days after the Signal leak, the Pentagon warned the app was the target of hackers
- Created article from nytimes usage top initial rank 1 with title 'Top Officials Reject Responsibility for Information Shared in Signal Chat
- Created article from nytimes usage candidate initial rank 2 with title 'Now Europe Knows What the Trump Team Calls It Behind Its Back: ‘Pathetic’
- Created article from nytimes usage candidate initial rank 3 with title 'After Signal Leak, JD Vance Focuses on Proving His Loyalty to Trump