### PR TITLE
Article updates: 20250729T1030

### DIFF
--- a/articles/20250729T1030-npr-as-gaza-starves-the-next-generation-may-also-endure-the-consequences.md
+++ b/articles/20250729T1030-npr-as-gaza-starves-the-next-generation-may-also-endure-the-consequences.md
@@ -1,0 +1,9 @@
+---
+url: https://www.npr.org/2025/07/29/g-s1-79039/gaza-children-starvation-health-risks
+title: As Gaza starves, the next generation may also endure the consequences
+publisher: npr
+usage: candidate
+initial_rank: 2
+---
+## Article summary
+The hunger crisis in Gaza has reached alarming levels, with a third of the population going days without food and a quarter experiencing famine-like conditions. Nearly 100,000 women and children suffer from severe acute malnutrition, and chronic hunger can have long-lasting effects on health and gene function, potentially impacting future generations. The crisis escalated after Israel blocked aid deliveries and resumed bombardments, leading to a reduction in aid distribution points and increased violence around aid sites. Children are particularly vulnerable, with malnutrition stunting physical and brain development and increasing the risk of future health conditions. While recovery is possible with early intervention and consistent care, the long-term effects of malnutrition and trauma can be profound, affecting not only survivors but also their descendants.

--- a/articles/20250729T1030-npr-dhs-is-urging-daca-recipients-to-self-deport.md
+++ b/articles/20250729T1030-npr-dhs-is-urging-daca-recipients-to-self-deport.md
@@ -1,0 +1,9 @@
+---
+url: https://www.npr.org/2025/07/29/nx-s1-5482923/dhs-daca-recipients-self-deport
+title: DHS is urging DACA recipients to self-deport
+publisher: npr
+usage: top
+initial_rank: 1
+---
+## Article summary
+The Trump administration is urging DACA recipients, known as Dreamers, to self-deport, despite the program offering temporary protection from deportation and work permits. The Department of Homeland Security (DHS) has stated that DACA does not confer legal status and that recipients may still be subject to arrest and deportation, particularly if they commit crimes. Recent actions, such as making DACA recipients ineligible for federal healthcare and investigating universities offering financial aid to them, have raised concerns about the administration's stance on the program. Immigrant advocates argue that these actions undermine DACA's protections and create fear among recipients, who have been detained or deported in various incidents. Despite public support for creating a legal pathway for DACA recipients, the administration's mixed messaging and strict enforcement have left many Dreamers uncertain about their future in the U.S.

--- a/articles/20250729T1030-npr-trump-lawsuit-against-murdoch-and-wall-street-journal-turns-personal.md
+++ b/articles/20250729T1030-npr-trump-lawsuit-against-murdoch-and-wall-street-journal-turns-personal.md
@@ -1,0 +1,9 @@
+---
+url: https://www.npr.org/2025/07/29/nx-s1-5482955/trump-epstein-murdoch-deposition-lawsuit
+title: 'Trump lawsuit against Murdoch and ''Wall Street Journal'' turns personal '
+publisher: npr
+usage: candidate
+initial_rank: 3
+---
+## Article summary
+President Trump has filed a defamation lawsuit against Rupert Murdoch and the *Wall Street Journal*, alleging that the newspaper published a fake birthday greeting he supposedly sent to Jeffrey Epstein. Trump claims he personally warned Murdoch about the falsity of the story, but it was published anyway. He is now seeking to compel Murdoch to testify under oath within 15 days, citing Murdoch's advanced age and health issues as reasons for urgency. The lawsuit highlights the strained relationship between the two former allies, with Trump accusing Murdoch of directing the publication of defamatory content. Meanwhile, the *Journal* has continued to report on Trump's connections to Epstein, further escalating tensions.

--- a/articles/20250729T1030-nytimes-at-slain-officers-home-his-bangladeshi-community-mourns-into-the-night.md
+++ b/articles/20250729T1030-nytimes-at-slain-officers-home-his-bangladeshi-community-mourns-into-the-night.md
@@ -1,0 +1,9 @@
+---
+url: https://www.nytimes.com/2025/07/29/nyregion/nyc-shooting-police-officer-killed-didarul-islam.html
+title: "At Slain Officer\u2019s Home, His Bangladeshi Community Mourns Into the Night"
+publisher: nytimes
+usage: candidate
+initial_rank: 3
+---
+## Article summary
+The Bangladeshi community in New York City mourns the loss of Officer Didarul Islam, a 36-year-old immigrant and three-and-a-half-year veteran of the NYPD, who was killed in a shooting at a Park Avenue skyscraper. Officer Islam, a father of two with a third child on the way, was the first to die in the massacre, which left four others dead, including the gunman. He was remembered as a devoted family man, a pillar in his largely Bangladeshi neighborhood, and a mentor to young men in the community. Officer Islam had started his career as a security guard at a school before joining the Police Department, inspired by his love for law enforcement and his desire to leave a legacy for his family. His community gathered to pay their respects, with many recalling his kindness, dedication, and the positive impact he had on those around him.

--- a/articles/20250729T1030-nytimes-investigators-seek-answers-in-deadly-mass-shooting.md
+++ b/articles/20250729T1030-nytimes-investigators-seek-answers-in-deadly-mass-shooting.md
@@ -1,0 +1,9 @@
+---
+url: https://www.nytimes.com/live/2025/07/29/nyregion/nyc-shooting-manhattan
+title: Investigators Seek Answers in Deadly Mass Shooting
+publisher: nytimes
+usage: candidate
+initial_rank: 2
+---
+## Article summary
+A gunman, identified as Shane Devon Tamura, killed four people, including a New York City police officer, Didarul Islam, in a Midtown Manhattan office tower at 345 Park Avenue. The shooting occurred on Monday evening, with the gunman driving from Las Vegas to New York City, crossing several states before the attack. Officer Islam, a three-and-a-half-year veteran of the NYPD and an immigrant from Bangladesh, was the first to be shot and was working off-duty as a security guard. The gunman, who had a documented mental health history, shot several people in the lobby before taking an elevator to the 33rd floor, where he killed one more person and then fatally shot himself. The building, owned by Rudin Management, houses offices for the National Football League, the investment firm Blackstone, and other companies, and is located in a busy commercial district of Midtown Manhattan.

--- a/articles/20250729T1030-nytimes-shooting-in-midtown-manhattan-tower-leaves-4-dead-including-police-officer.md
+++ b/articles/20250729T1030-nytimes-shooting-in-midtown-manhattan-tower-leaves-4-dead-including-police-officer.md
@@ -1,0 +1,9 @@
+---
+url: https://www.nytimes.com/2025/07/29/nyregion/officer-killing-midtown-shooting.html
+title: Shooting in Midtown Manhattan Tower Leaves 4 Dead, Including Police Officer
+publisher: nytimes
+usage: top
+initial_rank: 1
+---
+## Article summary
+A gunman armed with an assault-style rifle entered a Midtown Manhattan skyscraper on Monday evening, killing a New York City police officer, three other individuals, and critically injuring a fifth before taking his own life. Three victims were shot in the building's lobby, while the fourth was killed on an upper floor. The gunman then shot himself in the chest. Tenants of the building, located at 345 Park Avenue, went into lockdown as panic spread. Witnesses reported hearing rapid gunshots and seeing people fleeing the scene in distress.


### PR DESCRIPTION
- article from npr usage top initial rank 1 with title 'DHS is urging DACA recipients to self-deport ![](https://media.thiswas.news/screenshot/20250729T1030/20250729T1030-npr-dhs-is-urging-daca-recipients-to-self-deport.topcrop.png)
- article from npr usage candidate initial rank 2 with title 'As Gaza starves, the next generation may also endure the consequences ![](https://media.thiswas.news/screenshot/20250729T1030/20250729T1030-npr-as-gaza-starves-the-next-generation-may-also-endure-the-consequences.topcrop.png)
- article from npr usage candidate initial rank 3 with title 'Trump lawsuit against Murdoch and 'Wall Street Journal' turns personal  ![](https://media.thiswas.news/screenshot/20250729T1030/20250729T1030-npr-trump-lawsuit-against-murdoch-and-wall-street-journal-turns-personal.topcrop.png)
- article from nytimes usage top initial rank 1 with title 'Shooting in Midtown Manhattan Tower Leaves 4 Dead, Including Police Officer ![](https://media.thiswas.news/screenshot/20250729T1030/20250729T1030-nytimes-shooting-in-midtown-manhattan-tower-leaves-4-dead-including-police-officer.topcrop.png)
- article from nytimes usage candidate initial rank 2 with title 'Investigators Seek Answers in Deadly Mass Shooting ![](https://media.thiswas.news/screenshot/20250729T1030/20250729T1030-nytimes-investigators-seek-answers-in-deadly-mass-shooting.topcrop.png)
- article from nytimes usage candidate initial rank 3 with title 'At Slain Officer’s Home, His Bangladeshi Community Mourns Into the Night ![](https://media.thiswas.news/screenshot/20250729T1030/20250729T1030-nytimes-at-slain-officers-home-his-bangladeshi-community-mourns-into-the-night.topcrop.png)