### PR TITLE
Article updates: 20250730T1030

### DIFF
--- a/articles/20250730T1030-npr-88-magnitude-earthquake-sends-tsunami-into-coasts-of-russia-japan-and-alaska.md
+++ b/articles/20250730T1030-npr-88-magnitude-earthquake-sends-tsunami-into-coasts-of-russia-japan-and-alaska.md
@@ -1,0 +1,9 @@
+---
+url: https://www.npr.org/2025/07/29/nx-s1-5484324/8-8-magnitude-earthquake-sets-off-tsunami-warnings-in-japan-alaska-and-hawaii
+title: 8.8-magnitude earthquake sends tsunami into coasts of Russia, Japan and Alaska
+publisher: npr
+usage: top
+initial_rank: 1
+---
+## Article summary
+An 8.8-magnitude earthquake struck Russia's Far East early Wednesday, triggering tsunamis that affected Japan, Hawaii, and Alaska. Tsunami waves flooded ports in Kamchatka, Russia, and reached up to 4 meters in height, with smaller waves hitting Japan and Alaska. Authorities issued warnings and evacuations, with people fleeing to higher ground and traffic jams forming in Hawaii. The tsunami's impact was expected to last for hours or more, with multiple waves posing risks to coastal areas. The earthquake was one of the strongest recorded, with aftershocks and disruptions to transportation and power supplies reported.

--- a/articles/20250730T1030-npr-despite-grand-claims-a-new-report-shows-noncitizen-voting-hasnt-materialized.md
+++ b/articles/20250730T1030-npr-despite-grand-claims-a-new-report-shows-noncitizen-voting-hasnt-materialized.md
@@ -1,0 +1,9 @@
+---
+url: https://www.npr.org/2025/07/30/nx-s1-5462836/noncitizen-voting-trump-ceir-review
+title: Despite grand claims, a new report shows noncitizen voting hasn't materialized
+publisher: npr
+usage: candidate
+initial_rank: 3
+---
+## Article summary
+Despite claims of widespread noncitizen voting influencing the 2024 election, a review by the Michigan Secretary of State found only 16 credible cases out of 5.7 million votes cast. A new report by the Center for Election Innovation & Research (CEIR) confirms that noncitizen voting occurs in minuscule numbers and lacks coordination. Michigan's audit, using DHS resources, found that noncitizen voting is extremely rare, with only 0.00028% of votes cast by noncitizens. The report highlights disparities in how states investigate and disclose data on noncitizen voting, with some states inflating numbers for political purposes. Experts argue that noncitizen voting is not a significant threat due to safeguards, the risk of deportation, and the lack of evidence supporting widespread fraud.

--- a/articles/20250730T1030-npr-three-fired-doj-workers-add-to-chorus-of-layoffs-in-foundering-workforce.md
+++ b/articles/20250730T1030-npr-three-fired-doj-workers-add-to-chorus-of-layoffs-in-foundering-workforce.md
@@ -1,0 +1,9 @@
+---
+url: https://www.npr.org/2025/07/30/nx-s1-5476311/trump-fired-workers-justice-department
+title: Three fired DOJ workers add to chorus of layoffs in 'foundering' workforce
+publisher: npr
+usage: candidate
+initial_rank: 2
+---
+## Article summary
+The Department of Justice (DOJ) has seen hundreds of employees fired this year, often without clear reasons, creating fear and transforming the workforce. Career civil servants like Ila Dess and Carolyn Fensten have lost their jobs abruptly, with Dess being terminated without explanation and Fensten dismissed due to her husband's app, ICEBlock, which tracks immigration agents. The Trump administration has used Article 2 powers to bypass civil service laws, leading to widespread layoffs. Former DOJ lawyer Erez Reuven, who was fired after revealing a wrongful deportation, has filed a whistleblower complaint alleging political appointees misled courts to expedite deportations. Reuven's actions highlight broader concerns about the DOJ's integrity and the treatment of career civil servants under the current administration.

--- a/articles/20250730T1030-nytimes-officials-in-california-warn-people-to-avoid-beaches.md
+++ b/articles/20250730T1030-nytimes-officials-in-california-warn-people-to-avoid-beaches.md
@@ -1,0 +1,9 @@
+---
+url: https://www.nytimes.com/2025/07/30/us/tsunami-warning-california.html
+title: Officials in California Warn People to Avoid Beaches
+publisher: nytimes
+usage: candidate
+initial_rank: 2
+---
+## Article summary
+A tsunami warning was issued for Northern California after a powerful earthquake off Russia's eastern coast, with initial waves reaching 4.5 feet. The warning covered a 100-mile stretch of the Northern California coastline, from Cape Mendocino to the Oregon border, anticipating waves up to 5.5 feet high. Crescent City, known for its vulnerability to tsunamis due to its low elevation, recorded a 3.6-foot wave and has experienced 32 tsunamis since 1933, with five causing damage. The rest of the West Coast was under a tsunami advisory, with most areas expected to see waves of less than two feet. Authorities urged residents and beachgoers to stay inland and away from the water due to the potential danger from strong rip currents and powerful waves, even if they are relatively small.

--- a/articles/20250730T1030-nytimes-the-earthquake-could-be-one-of-the-largest-on-record.md
+++ b/articles/20250730T1030-nytimes-the-earthquake-could-be-one-of-the-largest-on-record.md
@@ -1,0 +1,7 @@
+---
+url: https://www.nytimes.com/2025/07/29/world/asia/earthquake-russia-record.html
+title: The Earthquake Could Be One of the Largest on Record
+publisher: nytimes
+usage: candidate
+initial_rank: 3
+---

--- a/articles/20250730T1030-nytimes-tsunami-waves-reach-us-west-coast-and-hawaii-after-quake.md
+++ b/articles/20250730T1030-nytimes-tsunami-waves-reach-us-west-coast-and-hawaii-after-quake.md
@@ -1,0 +1,9 @@
+---
+url: https://www.nytimes.com/live/2025/07/29/world/earthquake-tsunami-russia-japan-hawaii
+title: Tsunami Waves Reach U.S. West Coast and Hawaii After Quake
+publisher: nytimes
+usage: top
+initial_rank: 1
+---
+## Article summary
+An 8.8-magnitude earthquake near Russia triggered tsunami waves that reached Hawaii and the U.S. West Coast, with waves as high as 5.7 feet in Hawaii and 3.6 feet in California's Crescent City. Tsunami warnings were issued for Hawaii, Alaska, California, Russia, and Japan, prompting evacuations, but the worst fears did not materialize in Hawaii and Russia. The tsunami waves, moving at over 500 miles per hour, are not tall walls of water but sudden floods causing dangerous currents. Hawaii downgraded its tsunami warning to an advisory, with no major damage reported, while California continued to experience building waves. The tsunami also affected regions in Japan, French Polynesia, and other Pacific nations, with warnings issued for potential waves up to 13 feet in some areas.


### PR DESCRIPTION
- article from npr usage top initial rank 1 with title '8.8-magnitude earthquake sends tsunami into coasts of Russia, Japan and Alaska ![](https://media.thiswas.news/screenshot/20250730T1030/20250730T1030-npr-88-magnitude-earthquake-sends-tsunami-into-coasts-of-russia-japan-and-alaska.topcrop.png)
- article from npr usage candidate initial rank 2 with title 'Three fired DOJ workers add to chorus of layoffs in 'foundering' workforce ![](https://media.thiswas.news/screenshot/20250730T1030/20250730T1030-npr-three-fired-doj-workers-add-to-chorus-of-layoffs-in-foundering-workforce.topcrop.png)
- article from npr usage candidate initial rank 3 with title 'Despite grand claims, a new report shows noncitizen voting hasn't materialized ![](https://media.thiswas.news/screenshot/20250730T1030/20250730T1030-npr-despite-grand-claims-a-new-report-shows-noncitizen-voting-hasnt-materialized.topcrop.png)
- article from nytimes usage top initial rank 1 with title 'Tsunami Waves Reach U.S. West Coast and Hawaii After Quake ![](https://media.thiswas.news/screenshot/20250730T1030/20250730T1030-nytimes-tsunami-waves-reach-us-west-coast-and-hawaii-after-quake.topcrop.png)
- article from nytimes usage candidate initial rank 2 with title 'Officials in California Warn People to Avoid Beaches ![](https://media.thiswas.news/screenshot/20250730T1030/20250730T1030-nytimes-officials-in-california-warn-people-to-avoid-beaches.topcrop.png)
- article from nytimes usage candidate initial rank 3 with title 'The Earthquake Could Be One of the Largest on Record ![](https://media.thiswas.news/screenshot/20250730T1030/20250730T1030-nytimes-the-earthquake-could-be-one-of-the-largest-on-record.topcrop.png)