### PR TITLE
Article updates: 20250730T2230

### DIFF
--- a/articles/20250730T2230-npr-automakers-are-eating-the-cost-of-tariffs--for-now.md
+++ b/articles/20250730T2230-npr-automakers-are-eating-the-cost-of-tariffs--for-now.md
@@ -1,0 +1,9 @@
+---
+url: https://www.npr.org/2025/07/30/nx-s1-5482857/automakers-eating-tariff-costs
+title: "Automakers are eating the cost of tariffs \u2014 for now"
+publisher: npr
+usage: top
+initial_rank: 1
+---
+## Article summary
+Tariffs have significantly impacted the auto industry, increasing costs for materials like aluminum and steel, as well as foreign-made parts and imported vehicles. Despite these costs, automakers have not passed them on to consumers, with new vehicle transaction prices rising only 1.2% year over year in June, which is lower than the typical annual increase. Automakers have absorbed these costs, with companies like General Motors, Hyundai, Kia, and Volkswagen reporting substantial tariff bills. To mitigate the impact, some automakers are moving production to the United States and squeezing costs elsewhere. Eventually, however, executives indicate that costs will be passed on to consumers, with price increases expected for the 2026 model year vehicles, potentially rising by 4 to 8%. Additionally, consumers may see more subtle cost increases, such as higher financing rates and reduced cash back offers.

--- a/articles/20250730T2230-npr-kamala-harris-wont-run-for-california-governor.md
+++ b/articles/20250730T2230-npr-kamala-harris-wont-run-for-california-governor.md
@@ -1,0 +1,9 @@
+---
+url: https://www.kqed.org/news/12030198/prewrite-kamala-harris-enters-california-governor-race-upending-democratic-landscape
+title: Kamala Harris won't run for California governor
+publisher: npr
+usage: candidate
+initial_rank: 2
+---
+## Article summary
+Former Vice President Kamala Harris has announced she will not run for California governor in 2026, clearing the way for other prominent Democrats already in the race. Her decision allows other candidates to advance their campaigns without her significant influence on fundraising and name recognition. Notable Democratic candidates include former Health and Human Services Secretary Xavier Becerra, Lt. Gov. Eleni Kounalakis, and former Los Angeles Mayor Antonio Villaraigosa. Harris's decision also leaves the door open for a potential presidential bid in 2028. The Democratic field is strong, and any Republican candidate faces an uphill battle in a state that has not elected a Republican to statewide office since 2006.

--- a/articles/20250730T2230-npr-texas-republicans-release-a-redistricting-plan-that-could-achieve-trumps-aims.md
+++ b/articles/20250730T2230-npr-texas-republicans-release-a-redistricting-plan-that-could-achieve-trumps-aims.md
@@ -1,0 +1,9 @@
+---
+url: https://www.npr.org/2025/07/30/nx-s1-5485293/texas-redistricting-proposed-congressional-map
+title: Texas Republicans release a redistricting plan that could achieve Trump's aims
+publisher: npr
+usage: candidate
+initial_rank: 3
+---
+## Article summary
+Texas Republicans have proposed a new redistricting map aimed at securing up to five additional congressional seats for the GOP, aligning with President Trump's goals. The plan targets several Democratic-held districts, potentially forcing some Democratic incumbents to compete against each other. Analysts suggest the new map could result in 30 Republican-won districts compared to eight for Democrats, increasing the GOP's current 25-seat hold in Texas. Democrats have criticized the plan, with some considering fleeing the state to deny Republicans a legislative quorum, while others are raising funds to support competitive Democratic candidates. Legal challenges are expected, as the current Texas congressional map is already under litigation for alleged racial discrimination, and similar fights are ongoing in other states.

--- a/articles/20250730T2230-nytimes-brown-university-makes-a-deal-with-the-white-house-to-restore-funding.md
+++ b/articles/20250730T2230-nytimes-brown-university-makes-a-deal-with-the-white-house-to-restore-funding.md
@@ -1,0 +1,9 @@
+---
+url: https://www.nytimes.com/2025/07/30/us/brown-university-makes-a-deal-with-the-white-house-to-restore-funding.html
+title: Brown University Makes a Deal With the White House to Restore Funding
+publisher: nytimes
+usage: candidate
+initial_rank: 3
+---
+## Article summary
+Brown University has reached a deal with the White House to restore federal research funding, following pressure from the Trump administration. The agreement requires Brown to spend $50 million on state workforce development programs and comply with the administration's policies on issues like transgender athletes and merit-based admissions. In exchange, the government will restore millions in blocked research funds and will not dictate Brown's curriculum or academic speech. The deal comes amid accusations of antisemitism at Brown due to pro-Palestinian protests and follows similar agreements with the University of Pennsylvania and Columbia University. While the agreement has been criticized as capitulation, Brown's president, Christina H. Paxson, defended it as preserving academic integrity and allowing the university to move forward after a period of uncertainty.

--- a/articles/20250730T2230-nytimes-harris-will-not-run-for-california-governor.md
+++ b/articles/20250730T2230-nytimes-harris-will-not-run-for-california-governor.md
@@ -1,0 +1,7 @@
+---
+url: https://www.nytimes.com/2025/07/30/us/politics/harris-california-governor-race.html
+title: Harris Will Not Run for California Governor
+publisher: nytimes
+usage: top
+initial_rank: 1
+---

--- a/articles/20250730T2230-nytimes-texas-republicans-unveil-gerrymandered-house-map-at-trumps-request.md
+++ b/articles/20250730T2230-nytimes-texas-republicans-unveil-gerrymandered-house-map-at-trumps-request.md
@@ -1,0 +1,7 @@
+---
+url: https://www.nytimes.com/2025/07/30/us/politics/texas-republican-redistricting.html
+title: "Texas Republicans Unveil Gerrymandered House Map, at Trump\u2019s Request"
+publisher: nytimes
+usage: candidate
+initial_rank: 2
+---


### PR DESCRIPTION
- article from npr usage top initial rank 1 with title 'Automakers are eating the cost of tariffs — for now ![](https://media.thiswas.news/screenshot/20250730T2230/20250730T2230-npr-automakers-are-eating-the-cost-of-tariffs--for-now.topcrop.png)
- article from npr usage candidate initial rank 2 with title 'Kamala Harris won't run for California governor ![](https://media.thiswas.news/screenshot/20250730T2230/20250730T2230-npr-kamala-harris-wont-run-for-california-governor.topcrop.png)
- article from npr usage candidate initial rank 3 with title 'Texas Republicans release a redistricting plan that could achieve Trump's aims ![](https://media.thiswas.news/screenshot/20250730T2230/20250730T2230-npr-texas-republicans-release-a-redistricting-plan-that-could-achieve-trumps-aims.topcrop.png)
- article from nytimes usage top initial rank 1 with title 'Harris Will Not Run for California Governor ![](https://media.thiswas.news/screenshot/20250730T2230/20250730T2230-nytimes-harris-will-not-run-for-california-governor.topcrop.png)
- article from nytimes usage candidate initial rank 2 with title 'Texas Republicans Unveil Gerrymandered House Map, at Trump’s Request ![](https://media.thiswas.news/screenshot/20250730T2230/20250730T2230-nytimes-texas-republicans-unveil-gerrymandered-house-map-at-trumps-request.topcrop.png)
- article from nytimes usage candidate initial rank 3 with title 'Brown University Makes a Deal With the White House to Restore Funding ![](https://media.thiswas.news/screenshot/20250730T2230/20250730T2230-nytimes-brown-university-makes-a-deal-with-the-white-house-to-restore-funding.topcrop.png)