### PR TITLE
Article updates: 20250802T2230

### DIFF
--- a/articles/20250802T2230-npr-corporation-for-public-broadcasting-says-its-shutting-down.md
+++ b/articles/20250802T2230-npr-corporation-for-public-broadcasting-says-its-shutting-down.md
@@ -1,0 +1,9 @@
+---
+url: https://www.npr.org/2025/08/01/nx-s1-5489808/cpb-shut-down-public-broadcasting-trump
+title: Corporation for Public Broadcasting says it's shutting down
+publisher: npr
+usage: candidate
+initial_rank: 2
+---
+## Article summary
+The Corporation for Public Broadcasting (CPB) announced it will shut down by September 30, 2025, following the loss of all federal funding. This decision comes after President Trump signed a law cutting $1.1 billion in funding for public broadcasting through 2027, part of a broader $9 billion rescissions package. CPB President and CEO Patricia Harrison stated that despite public efforts to preserve funding, the organization must close, emphasizing its commitment to a transparent transition. The closure will eliminate most staff positions by the end of the fiscal year, with a small team remaining until January to handle financial obligations. Public media stations, particularly those in rural and underserved areas, will be significantly impacted, with some already experiencing layoffs and others seeing increased donations.

--- a/articles/20250802T2230-npr-in-gaza-more-palestinians-are-killed-while-waiting-for-food-aid.md
+++ b/articles/20250802T2230-npr-in-gaza-more-palestinians-are-killed-while-waiting-for-food-aid.md
@@ -1,0 +1,9 @@
+---
+url: https://www.npr.org/2025/08/02/nx-s1-5490943/gaza-palestinians-deaths-food-aid
+title: In Gaza, more Palestinians are killed while waiting for food aid
+publisher: npr
+usage: top
+initial_rank: 1
+---
+## Article summary
+In Gaza, at least 325 Palestinians have been killed by Israeli forces while trying to access food aid over the past week, with 24 deaths reported on Saturday alone. Despite Israel's claims of humanitarian pauses, food distribution remains perilous, with aid often looted by armed gangs and desperate crowds. International aid agencies and U.N. experts condemn Israel's restrictions on aid, calling them collective punishment and highlighting the worsening famine in Gaza. U.S. officials recently visited a food distribution site run by the Gaza Humanitarian Foundation (GHF), which has faced criticism amid reports of violence near its locations. Meanwhile, hostage families in Tel Aviv protest for a ceasefire, and U.S. Jewish organizations provide aid to Christians in Gaza, including the restoration of a damaged church.

--- a/articles/20250802T2230-npr-tea-encouraged-its-users-to-spill-then-the-apps-data-got-leaked.md
+++ b/articles/20250802T2230-npr-tea-encouraged-its-users-to-spill-then-the-apps-data-got-leaked.md
@@ -1,0 +1,9 @@
+---
+url: https://www.npr.org/2025/08/02/nx-s1-5483886/tea-app-breach-hacked-whisper-networks
+title: Tea encouraged its users to spill. Then the app's data got leaked
+publisher: npr
+usage: candidate
+initial_rank: 3
+---
+## Article summary
+The Tea app, designed to help women share information about potential online matches, suffered a major data breach, exposing sensitive user data including driver's licenses, direct messages, and selfies. The breach, discovered on July 25, led to users' personal information being leaked on the 4chan message board, including government IDs used for verification. The company, which has over 6.2 million users, faces two class-action lawsuits in California following the breach. Experts highlight the risks of digital "whisper networks," which, while intended to protect women, can lead to unchecked accusations and online mob behavior. The breach also resulted in real-world consequences, with users facing threats and the potential for defamation lawsuits, underscoring the complex nature of online information sharing.

--- a/articles/20250802T2230-nytimes-after-a-lag-consumers-begin-to-feel-the-pinch-of-tariffs.md
+++ b/articles/20250802T2230-nytimes-after-a-lag-consumers-begin-to-feel-the-pinch-of-tariffs.md
@@ -1,0 +1,7 @@
+---
+url: https://www.nytimes.com/2025/08/02/business/trump-tariffs-consumer-prices.html
+title: After a Lag, Consumers Begin to Feel the Pinch of Tariffs
+publisher: nytimes
+usage: top
+initial_rank: 1
+---

--- a/articles/20250802T2230-nytimes-lashing-out-over-russia-and-jobs-data-trump-displays-his-volatile-side.md
+++ b/articles/20250802T2230-nytimes-lashing-out-over-russia-and-jobs-data-trump-displays-his-volatile-side.md
@@ -1,0 +1,9 @@
+---
+url: https://www.nytimes.com/2025/08/02/us/politics/trump-russia-jobs.html
+title: Lashing Out Over Russia and Jobs Data, Trump Displays His Volatile Side
+publisher: nytimes
+usage: candidate
+initial_rank: 3
+---
+## Article summary
+The document discusses President Trump's volatile reactions to recent events, including the July jobs report and provocative posts by a Russian figure, Dmitry Medvedev. Trump accused the Bureau of Labor Statistics of manipulating job numbers and fired its commissioner, Erika McEntarfer. He also responded aggressively to Medvedev's nuclear war remarks by ordering submarines into position. The article highlights Trump's growing intolerance towards those who oppose him, including Federal Reserve Chair Jerome Powell and his own supporters. Critics argue that Trump's actions undermine government independence and set dangerous precedents, while his allies defend his use of presidential powers to enact his agenda.

--- a/articles/20250802T2230-nytimes-the-stock-market-is-good-bad-and-ugly-often-in-quick-succession.md
+++ b/articles/20250802T2230-nytimes-the-stock-market-is-good-bad-and-ugly-often-in-quick-succession.md
@@ -1,0 +1,7 @@
+---
+url: https://www.nytimes.com/2025/08/01/business/stock-market-best-worst-days-investing.html
+title: The Stock Market Is Good, Bad and Ugly, Often in Quick Succession
+publisher: nytimes
+usage: candidate
+initial_rank: 2
+---


### PR DESCRIPTION
- article from npr usage top initial rank 1 with title 'In Gaza, more Palestinians are killed while waiting for food aid ![](https://media.thiswas.news/screenshot/20250802T2230/20250802T2230-npr-in-gaza-more-palestinians-are-killed-while-waiting-for-food-aid.topcrop.png)
- article from npr usage candidate initial rank 2 with title 'Corporation for Public Broadcasting says it's shutting down ![](https://media.thiswas.news/screenshot/20250802T2230/20250802T2230-npr-corporation-for-public-broadcasting-says-its-shutting-down.topcrop.png)
- article from npr usage candidate initial rank 3 with title 'Tea encouraged its users to spill. Then the app's data got leaked ![](https://media.thiswas.news/screenshot/20250802T2230/20250802T2230-npr-tea-encouraged-its-users-to-spill-then-the-apps-data-got-leaked.topcrop.png)
- article from nytimes usage top initial rank 1 with title 'After a Lag, Consumers Begin to Feel the Pinch of Tariffs ![](https://media.thiswas.news/screenshot/20250802T2230/20250802T2230-nytimes-after-a-lag-consumers-begin-to-feel-the-pinch-of-tariffs.topcrop.png)
- article from nytimes usage candidate initial rank 2 with title 'The Stock Market Is Good, Bad and Ugly, Often in Quick Succession ![](https://media.thiswas.news/screenshot/20250802T2230/20250802T2230-nytimes-the-stock-market-is-good-bad-and-ugly-often-in-quick-succession.topcrop.png)
- article from nytimes usage candidate initial rank 3 with title 'Lashing Out Over Russia and Jobs Data, Trump Displays His Volatile Side ![](https://media.thiswas.news/screenshot/20250802T2230/20250802T2230-nytimes-lashing-out-over-russia-and-jobs-data-trump-displays-his-volatile-side.topcrop.png)