### PR TITLE
Article updates: 20250807T1030

### DIFF
--- a/articles/20250807T1030-npr-dhs-took-5-days-to-fund-texas-flooding-hotline-federal-records-show.md
+++ b/articles/20250807T1030-npr-dhs-took-5-days-to-fund-texas-flooding-hotline-federal-records-show.md
@@ -1,0 +1,9 @@
+---
+url: https://www.npr.org/2025/08/07/nx-s1-5489682/fema-call-center-dhs-funding-texas-floods
+title: DHS took 5 days to fund Texas flooding hotline, federal records show
+publisher: npr
+usage: top
+initial_rank: 1
+---
+## Article summary
+After floods devastated Texas Hill Country in July 2025, most calls to FEMA's disaster assistance hotline went unanswered due to a lapse in funding from the Department of Homeland Security (DHS). The funding delay, which lasted five days, was attributed to an administrative bottleneck where DHS Secretary Kristi Noem personally approves all large funding requests. This process differed from previous administrations, where the FEMA administrator had the authority to approve such expenditures. The lapse resulted in FEMA call centers answering only about 15,000 of the approximately 55,000 calls received from disaster survivors between July 6 and July 10. The delay caused significant backlogs, with survivors waiting over 90 minutes to get through. FEMA's acting administrator, David Richardson, sent a memo to Noem on July 10, highlighting the dire effects of the delay and requesting immediate funding approval. The funding was approved later that day, restoring adequate staffing to the call centers. Critics, including former FEMA officials and a Texas county commissioner, expressed frustration over the agency's understaffing and under-resourcing. FEMA's statement claiming swift and efficient response contradicted internal call logs and Richardson's memo. The incident raised concerns about the agency's preparedness and the impact of recent staff reductions under the Trump administration.

--- a/articles/20250807T1030-npr-trumps-broad-tariffs-go-into-effect-just-as-economic-pain-is-surfacing.md
+++ b/articles/20250807T1030-npr-trumps-broad-tariffs-go-into-effect-just-as-economic-pain-is-surfacing.md
@@ -1,0 +1,9 @@
+---
+url: https://www.npr.org/2025/08/07/nx-s1-5495218/trump-tariffs-trade-economy
+title: Trump's broad tariffs go into effect, just as economic pain is surfacing
+publisher: npr
+usage: candidate
+initial_rank: 3
+---
+## Article summary
+President Donald Trump implemented broad tariffs on imports from over 60 countries and the European Union, with rates ranging from 10% to 20%, aiming to boost U.S. manufacturing and investment. Despite Trump's optimism about unprecedented growth, economic indicators show signs of strain, including stalled hiring, rising inflation, and declining home values. Experts warn of long-term damage to the economy, with potential job losses and reduced workers' real wages. The tariffs, intended to reduce the trade deficit, have so far led to increased imports and a higher trade imbalance. The implementation process has been chaotic, with unclear timelines and frequent changes. Legal challenges to Trump's use of a 1977 law to impose tariffs may further complicate the situation. While the stock market has rebounded, critics argue that the tariffs are driven by Trump's personal opinions and could lead to legal and economic challenges. The ultimate impact of the tariffs remains uncertain, with potential consequences playing out over months or years. As Trump predicts an economic boom, many Americans are already feeling the effects of the uncertainty.

--- a/articles/20250807T1030-npr-video-shows-department-of-justice-official-urging-jan-6-rioters-to-kill-cops.md
+++ b/articles/20250807T1030-npr-video-shows-department-of-justice-official-urging-jan-6-rioters-to-kill-cops.md
@@ -1,0 +1,10 @@
+---
+url: https://www.npr.org/2025/08/07/nx-s1-5493197/doj-trump-jan-6-defendant-jared-wise-capitol-riot
+title: 'Video shows Department of Justice official urging Jan. 6 rioters to ''kill''
+  cops '
+publisher: npr
+usage: candidate
+initial_rank: 2
+---
+## Article summary
+Video footage and transcripts from January 6, 2021, show Jared Wse, now a senior advisor at the Department of Justice, berating and encouraging rioters to attack police officers. Wse, a former FBI agent, was not convicted of any crimes related to the Capitol riot due to President Trump's order to end all related prosecutions. He acknowledged yelling 'kill 'em' during the riot but claimed it was an angry reaction to perceived police brutality. Wse's trial was dismissed after Trump took office and ordered the case dropped. He now works on internal reviews of alleged 'weaponization' of law enforcement. The Trump administration has pardoned over 1,500 January 6 defendants and closed active investigations into assaults on police. The administration has also settled a wrongful death suit related to the riot and demoted or fired prosecutors who worked on January 6 cases. Conservative activist Ed Martn, appointed as U.S. Pardon Attorney, has suggested that violence against police on January 6 may have been justified due to conspiracy theories about the event being 'staged'. The hiring of former January 6 defendants by the administration highlights its efforts to rewrite the history of the Capitol riot.

--- a/articles/20250807T1030-nytimes-as-trumps-tariffs-reorder-world-trade-hardest-hit-countries-rush-to-respond.md
+++ b/articles/20250807T1030-nytimes-as-trumps-tariffs-reorder-world-trade-hardest-hit-countries-rush-to-respond.md
@@ -1,0 +1,10 @@
+---
+url: https://www.nytimes.com/live/2025/08/06/business/tariffs-trump-trade
+title: "As Trump\u2019s Tariffs Reorder World Trade, Hardest-Hit Countries Rush to\
+  \ Respond"
+publisher: nytimes
+usage: top
+initial_rank: 1
+---
+## Article summary
+President Trump's new tariffs on virtually every U.S. trading partner mark a significant step in his attempt to reorder global trade, leaving some of the hardest-hit governments scrambling to respond. Major U.S. trade partners, including the European Union, Japan, and South Korea, will face a 15% tariff on their exports to the United States, while other countries face higher tariffs, such as Taiwan with a 20% levy. Trump has doubled tariffs on India to 50% as punishment for its continued purchase of Russian oil. The highest tariff for any developed nation, 39%, has gone into effect for Switzerland. The tariffs are expected to drive up prices for American consumers and businesses. Trump's tariff agenda has seen many twists and turns since he first proclaimed 'Liberation Day' this spring. The tariffs are part of Trump's long-time goal to smash a global trade system he believes has robbed America of jobs and money, but critics argue it will leave the U.S. economically and diplomatically isolated. The tariffs do not include China, which remains in an uneasy truce with the United States. The current 90-day pause on trade between the world's largest economies is set to expire on Tuesday. The new tariffs apply to dozens of nations and will take effect on August 7, with most facing tariffs between 15 and 50%.

--- a/articles/20250807T1030-nytimes-chinas-exports-surged-again-in-july-but-not-to-america.md
+++ b/articles/20250807T1030-nytimes-chinas-exports-surged-again-in-july-but-not-to-america.md
@@ -1,0 +1,9 @@
+---
+url: https://www.nytimes.com/2025/08/07/business/economy/china-tariffs-exports-imports.html
+title: "China\u2019s Exports Surged Again in July, but Not to America"
+publisher: nytimes
+usage: candidate
+initial_rank: 3
+---
+## Article summary
+China's exports surged in July, driven by companies rushing to ship goods to Southeast Asia, Africa, and the European Union ahead of increased U.S. tariffs. Overall exports rose by 7.2% year-over-year, with significant growth in regions often used for re-exporting to the U.S. Exports to the U.S. directly decreased by over a fifth due to tariff concerns. China's economy relies heavily on exports, partly due to a decline in domestic consumption. The U.S. trade deficit with China has narrowed due to tariffs, but China still exports three times as much to the U.S. as it imports. Chinese companies are diversifying exports to the European Union and developing countries. The U.S. has increased tariffs to boost domestic manufacturing and reduce dependence on China. A key question is whether the U.S. will further curb transshipment of goods through other countries. China has been moving production to countries like Vietnam, Malaysia, and Mexico to bypass U.S. tariffs. Some Southeast Asian and African countries are increasing tariffs to protect their own industries from Chinese competition.

--- a/articles/20250807T1030-nytimes-japans-auto-giants-are-expecting-pain-despite-trump-trade-deal.md
+++ b/articles/20250807T1030-nytimes-japans-auto-giants-are-expecting-pain-despite-trump-trade-deal.md
@@ -1,0 +1,9 @@
+---
+url: https://www.nytimes.com/2025/08/07/business/tariffs-japan-cars.html
+title: "Japan\u2019s Auto Giants Are Expecting Pain Despite Trump Trade Deal"
+publisher: nytimes
+usage: candidate
+initial_rank: 2
+---
+## Article summary
+Japan's major automakers, including Toyota, Honda, and Nissan, anticipate minimal financial relief from the recent U.S.-Japan trade deal. The agreement aims to reduce U.S. tariffs on imported cars and parts to 15%, down from 27.5%, but this rate remains six times higher than earlier this year. Despite the reduction, the new tariff rates have not yet been implemented, causing confusion about their timeline. The automakers forecast minimal benefits to their profits, casting a gloomy outlook on their earnings. The automotive industry is crucial to Japan's economy, being its largest export to the U.S. and a significant employer. The trade deal's impact on profits is seen as limited, with the lower tariffs still posing challenges. The uncertainty and delayed implementation further dampen expectations. Overall, the trade deal is not expected to provide substantial financial relief to Japan's auto giants.


### PR DESCRIPTION
- article from npr usage top initial rank 1 with title 'DHS took 5 days to fund Texas flooding hotline, federal records show ![](https://media.thiswas.news/screenshot/20250807T1030/20250807T1030-npr-dhs-took-5-days-to-fund-texas-flooding-hotline-federal-records-show.topcrop.png)
- article from npr usage candidate initial rank 2 with title 'Video shows Department of Justice official urging Jan. 6 rioters to 'kill' cops  ![](https://media.thiswas.news/screenshot/20250807T1030/20250807T1030-npr-video-shows-department-of-justice-official-urging-jan-6-rioters-to-kill-cops.topcrop.png)
- article from npr usage candidate initial rank 3 with title 'Trump's broad tariffs go into effect, just as economic pain is surfacing ![](https://media.thiswas.news/screenshot/20250807T1030/20250807T1030-npr-trumps-broad-tariffs-go-into-effect-just-as-economic-pain-is-surfacing.topcrop.png)
- article from nytimes usage top initial rank 1 with title 'As Trump’s Tariffs Reorder World Trade, Hardest-Hit Countries Rush to Respond ![](https://media.thiswas.news/screenshot/20250807T1030/20250807T1030-nytimes-as-trumps-tariffs-reorder-world-trade-hardest-hit-countries-rush-to-respond.topcrop.png)
- article from nytimes usage candidate initial rank 2 with title 'Japan’s Auto Giants Are Expecting Pain Despite Trump Trade Deal ![](https://media.thiswas.news/screenshot/20250807T1030/20250807T1030-nytimes-japans-auto-giants-are-expecting-pain-despite-trump-trade-deal.topcrop.png)
- article from nytimes usage candidate initial rank 3 with title 'China’s Exports Surged Again in July, but Not to America ![](https://media.thiswas.news/screenshot/20250807T1030/20250807T1030-nytimes-chinas-exports-surged-again-in-july-but-not-to-america.topcrop.png)